### PR TITLE
Add PostgreSQL version to Docker development image tags

### DIFF
--- a/ferretdb_packaging/defineversion/main_test.go
+++ b/ferretdb_packaging/defineversion/main_test.go
@@ -87,7 +87,7 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~pr~define~version",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ghcr.io/ferretdb/postgres-documentdb-dev:pr-define-version",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-pr-define-version",
 				},
 			},
 		},
@@ -103,7 +103,7 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~pr~define~version",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ghcr.io/otherorg/postgres-otherrepo-dev:pr-define-version",
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-pr-define-version",
 				},
 			},
 		},
@@ -120,7 +120,7 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~pr~define~version",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ghcr.io/ferretdb/postgres-documentdb-dev:pr-define-version",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-pr-define-version",
 				},
 			},
 		},
@@ -136,7 +136,7 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~pr~define~version",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ghcr.io/otherorg/postgres-otherrepo-dev:pr-define-version",
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-pr-define-version",
 				},
 			},
 		},
@@ -153,9 +153,9 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~branch~ferretdb",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ferretdb/postgres-documentdb-dev:ferretdb",
-					"ghcr.io/ferretdb/postgres-documentdb-dev:ferretdb",
-					"quay.io/ferretdb/postgres-documentdb-dev:ferretdb",
+					"ferretdb/postgres-documentdb-dev:17-ferretdb",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
+					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 				},
 			},
 		},
@@ -171,7 +171,7 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~branch~ferretdb",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ghcr.io/otherorg/postgres-otherrepo-dev:ferretdb",
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb",
 				},
 			},
 		},
@@ -262,9 +262,9 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~branch~ferretdb",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ferretdb/postgres-documentdb-dev:ferretdb",
-					"ghcr.io/ferretdb/postgres-documentdb-dev:ferretdb",
-					"quay.io/ferretdb/postgres-documentdb-dev:ferretdb",
+					"ferretdb/postgres-documentdb-dev:17-ferretdb",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
+					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 				},
 			},
 		},
@@ -280,7 +280,7 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~branch~ferretdb",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ghcr.io/otherorg/postgres-otherrepo-dev:ferretdb",
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb",
 				},
 			},
 		},
@@ -297,9 +297,9 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~branch~ferretdb",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ferretdb/postgres-documentdb-dev:ferretdb",
-					"ghcr.io/ferretdb/postgres-documentdb-dev:ferretdb",
-					"quay.io/ferretdb/postgres-documentdb-dev:ferretdb",
+					"ferretdb/postgres-documentdb-dev:17-ferretdb",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
+					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 				},
 			},
 		},
@@ -315,7 +315,7 @@ func TestDefineVersion(t *testing.T) {
 			expectedDebian: "0.100.0~branch~ferretdb",
 			expectedDocker: &images{
 				developmentImages: []string{
-					"ghcr.io/otherorg/postgres-otherrepo-dev:ferretdb",
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb",
 				},
 			},
 		},


### PR DESCRIPTION
Closes FerretDB/FerretDB#4725.

See failing CI in FerretDB/FerretDB https://github.com/FerretDB/FerretDB/actions/runs/13641650920/job/38132657622?pr=4834.
```
        documentdb_test.go:68: 
            	Error Trace:	/home/runner/work/FerretDB/FerretDB/internal/documentdb/documentdb_test.go:68
            	Error:      	Not equal: 
            	            	expected: "PostgreSQL 16.8 (Debian 16.8-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit"
            	            	actual  : "PostgreSQL 15.12 (Debian 15.12-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-PostgreSQL 16.8 (Debian 16.8-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
            	            	+PostgreSQL 15.12 (Debian 15.12-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
            	Test:       	TestNewPool/Normal
            	Messages:   	version.PostgreSQL wasn't updated
```

The development documentdb docker build tag for branches and PRs should include PG version, so it can be used in FerretDB development like so https://github.com/FerretDB/FerretDB/pull/4853.