### PR TITLE
Fix handling of explicit `maxTimeMS` zero values

### DIFF
--- a/pg_documentdb/src/commands/commands_common.c
+++ b/pg_documentdb/src/commands/commands_common.c
@@ -173,7 +173,7 @@ IsCommonSpecIgnoredField(const char *fieldName)
 void
 SetExplicitStatementTimeout(int timeoutMilliseconds)
 {
-	if (!EnableBackendStatementTimeout)
+	if (!EnableBackendStatementTimeout || timeoutMilliseconds <= 0)
 	{
 		return;
 	}


### PR DESCRIPTION
Closes FerretDB/FerretDB#4973.