### PR TITLE
Build production docker images for branch and PR builds

### DIFF
--- a/packaging/defineversion/main.go
+++ b/packaging/defineversion/main.go
@@ -169,6 +169,9 @@ func defineVersionForBranch(controlDefaultVersion, pgVersion, owner, repo, branc
 		dockerDevelopmentImages: []string{
 			fmt.Sprintf("ghcr.io/%s/postgres-%s-dev:%s-ferretdb", owner, repo, pgVersion),
 		},
+		dockerProductionImages: []string{
+			fmt.Sprintf("ghcr.io/%s/postgres-%s-dev:%s-ferretdb-prod", owner, repo, pgVersion),
+		},
 		debian: fmt.Sprintf("%s~ferretdb", controlDefaultVersion),
 	}
 
@@ -183,7 +186,9 @@ func defineVersionForBranch(controlDefaultVersion, pgVersion, owner, repo, branc
 	}
 
 	res.dockerDevelopmentImages = append(res.dockerDevelopmentImages, fmt.Sprintf("quay.io/ferretdb/postgres-documentdb-dev:%s-ferretdb", pgVersion))
+	res.dockerProductionImages = append(res.dockerProductionImages, fmt.Sprintf("quay.io/ferretdb/postgres-documentdb-dev:%s-ferretdb-prod", pgVersion))
 	res.dockerDevelopmentImages = append(res.dockerDevelopmentImages, fmt.Sprintf("ferretdb/postgres-documentdb-dev:%s-ferretdb", pgVersion))
+	res.dockerProductionImages = append(res.dockerProductionImages, fmt.Sprintf("ferretdb/postgres-documentdb-dev:%s-ferretdb-prod", pgVersion))
 
 	return res, nil
 }

--- a/packaging/defineversion/main.go
+++ b/packaging/defineversion/main.go
@@ -150,6 +150,9 @@ func defineVersionForPR(controlDefaultVersion, pgVersion, owner, repo, branch st
 		dockerDevelopmentImages: []string{
 			fmt.Sprintf("ghcr.io/%s/postgres-%s-dev:%s-pr-%s", owner, repo, pgVersion, branch),
 		},
+		dockerProductionImages: []string{
+			fmt.Sprintf("ghcr.io/%s/postgres-%s-dev:%s-pr-%s-prod", owner, repo, pgVersion, branch),
+		},
 		debian: disallowedDebian.ReplaceAllString(fmt.Sprintf("%s-pr-%s", controlDefaultVersion, branch), "~"),
 	}
 

--- a/packaging/defineversion/main_test.go
+++ b/packaging/defineversion/main_test.go
@@ -91,6 +91,9 @@ func TestDefineVersion(t *testing.T) {
 				dockerDevelopmentImages: []string{
 					"ghcr.io/ferretdb/postgres-documentdb-dev:17-pr-define-version",
 				},
+				dockerProductionImages: []string{
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-pr-define-version-prod",
+				},
 				debian: "0.103.0~pr~define~version",
 			},
 		},
@@ -107,6 +110,9 @@ func TestDefineVersion(t *testing.T) {
 			expected: &versions{
 				dockerDevelopmentImages: []string{
 					"ghcr.io/otherorg/postgres-otherrepo-dev:17-pr-define-version",
+				},
+				dockerProductionImages: []string{
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-pr-define-version-prod",
 				},
 				debian: "0.103.0~pr~define~version",
 			},
@@ -126,6 +132,9 @@ func TestDefineVersion(t *testing.T) {
 				dockerDevelopmentImages: []string{
 					"ghcr.io/ferretdb/postgres-documentdb-dev:17-pr-define-version",
 				},
+				dockerProductionImages: []string{
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-pr-define-version-prod",
+				},
 				debian: "0.103.0~pr~define~version",
 			},
 		},
@@ -142,6 +151,9 @@ func TestDefineVersion(t *testing.T) {
 			expected: &versions{
 				dockerDevelopmentImages: []string{
 					"ghcr.io/otherorg/postgres-otherrepo-dev:17-pr-define-version",
+				},
+				dockerProductionImages: []string{
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-pr-define-version-prod",
 				},
 				debian: "0.103.0~pr~define~version",
 			},

--- a/packaging/defineversion/main_test.go
+++ b/packaging/defineversion/main_test.go
@@ -163,6 +163,11 @@ func TestDefineVersion(t *testing.T) {
 					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 				},
+				dockerProductionImages: []string{
+					"ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+				},
 				debian: "0.103.0~ferretdb",
 			},
 		},
@@ -179,6 +184,9 @@ func TestDefineVersion(t *testing.T) {
 			expected: &versions{
 				dockerDevelopmentImages: []string{
 					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb",
+				},
+				dockerProductionImages: []string{
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb-prod",
 				},
 				debian: "0.103.0~ferretdb",
 			},
@@ -307,6 +315,11 @@ func TestDefineVersion(t *testing.T) {
 					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 				},
+				dockerProductionImages: []string{
+					"ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+				},
 				debian: "0.103.0~ferretdb",
 			},
 		},
@@ -323,6 +336,9 @@ func TestDefineVersion(t *testing.T) {
 			expected: &versions{
 				dockerDevelopmentImages: []string{
 					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb",
+				},
+				dockerProductionImages: []string{
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb-prod",
 				},
 				debian: "0.103.0~ferretdb",
 			},
@@ -344,6 +360,11 @@ func TestDefineVersion(t *testing.T) {
 					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb",
 				},
+				dockerProductionImages: []string{
+					"ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+					"ghcr.io/ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+					"quay.io/ferretdb/postgres-documentdb-dev:17-ferretdb-prod",
+				},
 				debian: "0.103.0~ferretdb",
 			},
 		},
@@ -360,6 +381,9 @@ func TestDefineVersion(t *testing.T) {
 			expected: &versions{
 				dockerDevelopmentImages: []string{
 					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb",
+				},
+				dockerProductionImages: []string{
+					"ghcr.io/otherorg/postgres-otherrepo-dev:17-ferretdb-prod",
 				},
 				debian: "0.103.0~ferretdb",
 			},


### PR DESCRIPTION
Closes FerretDB/FerretDB#5227.