### PR TITLE
Fix `rpm` packaging

### DIFF
--- a/.github/workflows/ferretdb_packages.yml
+++ b/.github/workflows/ferretdb_packages.yml
@@ -85,7 +85,9 @@ jobs:
             pg: 15
           # TODO https://github.com/microsoft/documentdb/issues/259
           - arch: arm64
-            package: rpm
+            package: rhel8
+          - arch: arm64
+            package: rhel9
 
     name: .${{ matrix.package }} (${{ matrix.os }}, ${{ matrix.arch }}, Pg${{ matrix.pg }})
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Unfortunately I messed up path expression in workflow file in the previous PR, which is fixed by this, hence CI is failing.
<s>Also made changes to avoid hardcoding `x86_64`, which enabled building `arm64`.</s>

Closes FerretDB/FerretDB#5379.